### PR TITLE
更新 v8-profiler-node8 版本号为 6.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,6 @@
     "lodash": "^4.17.4",
     "pretty-bytes": "^4.0.2",
     "serve-favicon": "^2.4.3",
-    "v8-profiler-node8": "^5.7.8"
+    "v8-profiler-node8": "^6.0.1"
   }
 }


### PR DESCRIPTION
#81 